### PR TITLE
Fix: Exclude plan-*.md from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Plan files
+plan-*.md


### PR DESCRIPTION
This PR resolves issue #2 by adding `plan-*.md` to the `.gitignore` file.